### PR TITLE
Use logrus for logging, instead a mix of loggers

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,14 +1,13 @@
 package main
 
 import (
-	"log"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 )
 
 func init() {
-	logrus.SetLevel(logrus.DebugLevel)
+	log.SetLevel(log.DebugLevel)
 }
 
 func main() {


### PR DESCRIPTION
logrus was not properly being used, it was just initialised but then the
normal log was called.

The compiler was not complaining because the logrus package was used on
the `init()`.
